### PR TITLE
Fix accentuated characters in the card message

### DIFF
--- a/internal/parser/image.go
+++ b/internal/parser/image.go
@@ -23,6 +23,7 @@ const (
 	processingText   = "Em processamento"
 	installmentsText = "Parcela"
 	cardText         = "Cartao final"
+	cardTextAccent   = "Cartão final"
 	firstInstallment = "1/"
 	tesseractBin     = "/usr/bin/tesseract"
 )
@@ -31,7 +32,7 @@ var (
 	empty Transaction
 
 	regexDate         = regexp.MustCompile(`^(\d{2})\/(\d{2})\s*`)
-	regexCard         = regexp.MustCompile(`Cartao final\s*(\d+)`)
+	regexCard         = regexp.MustCompile(`Cart[aã]o final\s*(\d+)`)
 	regexValue        = regexp.MustCompile(`R\$\s*(-?[0-9.]+[, ]\d+)`)
 	regexInstallments = regexp.MustCompile(`Parcela.*(\d+)\s*de\s*(\d+)`)
 )
@@ -189,7 +190,7 @@ func parseTransaction(ct CurrentTime, line, ref string) Transaction {
 
 	// card
 
-	if strings.Contains(line, cardText) {
+	if strings.Contains(line, cardText) || strings.Contains(line, cardTextAccent) {
 		transaction.Memo += parseRegex(line, regexCard) + space
 	}
 	line = regexCard.ReplaceAllString(line, "")

--- a/internal/parser/ocr/ocr_test.go
+++ b/internal/parser/ocr/ocr_test.go
@@ -15,34 +15,34 @@ const parsedText = `30/01
 ESQUINA LISBOA Em processamento
 
 LANCHON SAO PAU R$ 64,24
-Cartao final 6137
+Cartão final 6137
 
 30/01
 E-GR COMERCI*EGR Em processamento
 
 R$ 48,03
 Comer SAO PAU Parcela 1 de 2
-Cartao final 4432
+Cartão final 4432
 
 29/01
 
 MP *ALIEXPRESS R$ 167,91
-Cartao final 4432
+Cartão final 4432
 
 29/01
 
 VENUTO R$ 92,21
-Cartao final 6137
+Cartão final 6137
 
 29/01
 
 DROGASIL1164 R$ 96,53
-Cartao final 8240
+Cartão final 8240
 
 29/01
 
 APPLE.COM/BILL R$ 14,90
-Cartao final 4432
+Cartão final 4432
 `
 
 func TestParse(t *testing.T) {

--- a/test/fixtures/transactions.txt
+++ b/test/fixtures/transactions.txt
@@ -2,7 +2,7 @@
 NOME DO Em processamento
 
 LUGAR  R$ 64,24
-Cartao final 1234
+Cartão final 1234
 
 
 __CURRENT__
@@ -14,7 +14,7 @@ Cartao final 4321
 __NEW__
 
 NOVO PARCELAMENTO
-Cartao final 4321
+Cartão final 4321
 
 R$ 70,75
 Parcela 1 de 4


### PR DESCRIPTION
Since we fixed the Tesseract's flag usage, the card message now understand accentuated characters.